### PR TITLE
Code refactor for maintainability and some bug fixes

### DIFF
--- a/demos/bootstrap/index.html
+++ b/demos/bootstrap/index.html
@@ -11,8 +11,8 @@
 		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css">
 		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
 		<!-- jQuery.NumPad -->
-		<script src="file:///C:/temp/webpage_to_test_jquery_numpad/jquery.numpad.js"></script>
-		<link rel="stylesheet" href="file:///C:/temp/webpage_to_test_jquery_numpad/jquery.numpad.css">
+		<script src="../../jquery.numpad.js"></script>
+		<link rel="stylesheet" href="../../jquery.numpad.css">
 		<script type="text/javascript">
 			// Set NumPad defaults for jQuery mobile. 
 			// These defaults will be applied to all NumPads within this document!

--- a/demos/bootstrap/index.html
+++ b/demos/bootstrap/index.html
@@ -11,30 +11,35 @@
 		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css">
 		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
 		<!-- jQuery.NumPad -->
-		<script src="../../jquery.numpad.js"></script>
-		<link rel="stylesheet" href="../../jquery.numpad.css">
+		<script src="file:///C:/temp/webpage_to_test_jquery_numpad/jquery.numpad.js"></script>
+		<link rel="stylesheet" href="file:///C:/temp/webpage_to_test_jquery_numpad/jquery.numpad.css">
 		<script type="text/javascript">
 			// Set NumPad defaults for jQuery mobile. 
 			// These defaults will be applied to all NumPads within this document!
-			$.fn.numpad.defaults.gridTpl = '<table class="table modal-content"></table>';
-			$.fn.numpad.defaults.backgroundTpl = '<div class="modal-backdrop in"></div>';
-			$.fn.numpad.defaults.displayTpl = '<input type="text" class="form-control" />';
-			$.fn.numpad.defaults.buttonNumberTpl =  '<button type="button" class="btn btn-default"></button>';
-			$.fn.numpad.defaults.buttonFunctionTpl = '<button type="button" class="btn" style="width: 100%;"></button>';
-			$.fn.numpad.defaults.onKeypadCreate = function(){$(this).find('.done').addClass('btn-primary');};
+			JQueryNumpad.defaults.gridTpl = '<table class="table modal-content"></table>';
+			JQueryNumpad.defaults.backgroundTpl = '<div class="modal-backdrop in"></div>';
+			JQueryNumpad.defaults.displayTpl = '<input type="text" class="form-control" />';
+			JQueryNumpad.defaults.buttonNumberTpl =  '<button type="button" class="btn btn-default"></button>';
+			JQueryNumpad.defaults.buttonFunctionTpl = '<button type="button" class="btn" style="width: 100%;"></button>';
+			JQueryNumpad.defaults.decimalSeparator = '.';
+			JQueryNumpad.defaults.onKeypadCreate = function(){$(this).find('.done').addClass('btn-primary');};
 			
 			// Instantiate NumPad once the page is ready to be shown
 			$(document).ready(function(){
 				$('#text-basic').numpad();
+
 				$('#password').numpad({
 					displayTpl: '<input class="form-control" type="password" />',
 					hidePlusMinusButton: true,
 					hideDecimalButton: true	
 				});
+				
 				$('#numpadButton-btn').numpad({
 					target: $('#numpadButton')
 				});
+				
 				$('#numpad4div').numpad();
+				
 				$('#numpad4column .qtyInput').numpad();
 				
 				$('#numpad4column tr').on('click', function(e){

--- a/demos/jquerymobile/index.html
+++ b/demos/jquerymobile/index.html
@@ -13,12 +13,12 @@
 		<script type="text/javascript">
 			// Set NumPad defaults for jQuery mobile. 
 			// These defaults will be applied to all NumPads within this document!
-			$.fn.numpad.defaults.gridTpl = '<table class="ui-bar-a"></table>';
-			$.fn.numpad.defaults.backgroundTpl = '<div class="ui-popup-screen ui-overlay-a"></div>';
-			$.fn.numpad.defaults.displayTpl = '<input data-theme="b" type="text" />';
-			$.fn.numpad.defaults.buttonNumberTpl =  '<a data-role="button" data-theme="b"></a>';
-			$.fn.numpad.defaults.buttonFunctionTpl = '<a data-role="button" data-theme="a"></a>';
-			$.fn.numpad.defaults.onKeypadCreate = function(){$(this).enhanceWithin();};
+			JQueryNumpad.defaults.gridTpl = '<table class="ui-bar-a"></table>';
+			JQueryNumpad.defaults.backgroundTpl = '<div class="ui-popup-screen ui-overlay-a"></div>';
+			JQueryNumpad.defaults.displayTpl = '<input data-theme="b" type="text" />';
+			JQueryNumpad.defaults.buttonNumberTpl =  '<a data-role="button" data-theme="b"></a>';
+			JQueryNumpad.defaults.buttonFunctionTpl = '<a data-role="button" data-theme="a"></a>';
+			JQueryNumpad.defaults.onKeypadCreate = function(){$(this).enhanceWithin();};
 			
 			// Instantiate NumPad once the page is ready to be shown
 			$(document).on('pageshow', function(){

--- a/jquery.numpad.css
+++ b/jquery.numpad.css
@@ -1,3 +1,35 @@
+/*
+	This file was forked from https://github.com/kabachello/jQuery.NumPad
+		with the license shown below.
+   
+	This license only applies to this file and others from the same project, which
+	also are prefixed with this header.  This file may have been modified, but the
+	license still applies.
+
+	----------------------------------------------------------------------------------
+   
+	The MIT License (MIT)
+
+	Copyright (c) 2014-2015 almasaeed2010
+
+	Permission is hereby granted, free of charge, to any person obtaining a copy of
+	this software and associated documentation files (the "Software"), to deal in
+	the Software without restriction, including without limitation the rights to
+	use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+	the Software, and to permit persons to whom the Software is furnished to do so,
+	subject to the following conditions:
+
+	The above copyright notice and this permission notice shall be included in all
+	copies or substantial portions of the Software.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+	FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+	COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+	IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+	CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
 .nmpd-wrapper {display: none;}
 .nmpd-target {cursor: pointer;}
 .nmpd-grid {position:absolute; left:50px; top:50px; z-index:5000; -khtml-user-select: none; padding:10px; width: initial;}

--- a/jquery.numpad.css
+++ b/jquery.numpad.css
@@ -1,35 +1,3 @@
-/*
-	This file was forked from https://github.com/kabachello/jQuery.NumPad
-		with the license shown below.
-   
-	This license only applies to this file and others from the same project, which
-	also are prefixed with this header.  This file may have been modified, but the
-	license still applies.
-
-	----------------------------------------------------------------------------------
-   
-	The MIT License (MIT)
-
-	Copyright (c) 2014-2015 almasaeed2010
-
-	Permission is hereby granted, free of charge, to any person obtaining a copy of
-	this software and associated documentation files (the "Software"), to deal in
-	the Software without restriction, including without limitation the rights to
-	use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-	the Software, and to permit persons to whom the Software is furnished to do so,
-	subject to the following conditions:
-
-	The above copyright notice and this permission notice shall be included in all
-	copies or substantial portions of the Software.
-
-	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-	FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-	COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-	IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-	CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
-
 .nmpd-wrapper {display: none;}
 .nmpd-target {cursor: pointer;}
 .nmpd-grid {position:absolute; left:50px; top:50px; z-index:5000; -khtml-user-select: none; padding:10px; width: initial;}

--- a/jquery.numpad.js
+++ b/jquery.numpad.js
@@ -265,8 +265,9 @@ class JQueryNumpad {
 
 	numpad_setValue = (value) => {
 		value = this._numpad_cutStringLengthToMaximumAllowed(value);
+		let nonnumericAllowedValues = ['', '-', this.options.decimalSeparator, `-${this.options.decimalSeparator}`];
 
-		if(!this._numpad_isValueNumeric(value) && value !== ""){
+		if(!this._numpad_isValueNumeric(value) && !nonnumericAllowedValues.includes(value)){
 			return;
 		}
 
@@ -300,13 +301,16 @@ class JQueryNumpad {
 	}
 
 	numpad_close = (target) => {
+		let finalValue = this.numpad_getValue().toString().replace('.', this.options.decimalSeparator);
+		let textToWrite = this._numpad_cutStringLengthToMaximumAllowed(finalValue)
+
 		// If a target element is given, set it's value to the dipslay value of the numpad. Otherwise just hide the numpad
 		if (target) {
 			if (target.prop("tagName") === 'INPUT') {
-				target.val(this.numpad_getValue().toString().replace('.', this.options.decimalSeparator));
+				target.val(textToWrite);
 			}
 			else {
-				target.html(this.numpad_getValue().toString().replace('.', this.options.decimalSeparator));
+				target.html(textToWrite);
 			}
 		}
 

--- a/jquery.numpad.js
+++ b/jquery.numpad.js
@@ -67,19 +67,19 @@
 		let numberPadElement = {};
 
 		// "this" is a jQuery selecton, which might contain many matches.
-		return this.each(function (_, target) {
+		return this.each(function (_, numpadTarget) {
 			if ($('#' + id).length === 0) {
 				numberPadElement = new JQueryNumpad(options, id);
 			}
 
-			$.data(target, 'numpad', numberPadElement);
+			$.data(numpadTarget, 'numpad', numberPadElement);
 
-			$(target).attr("readonly", true).attr('data-numpad', id).addClass('nmpd-target');
+			$(numpadTarget).attr("readonly", true).attr('data-numpad', id).addClass('nmpd-target');
 
-			$(target).bind(options.openOnEvent, function () {
+			$(numpadTarget).bind(options.openOnEvent, function () {
 				numberPadElement.numpad_open(options.target
 					? options.target
-					: $(target));
+					: $(numpadTarget));
 			});
 		});
 	};

--- a/jquery.numpad.js
+++ b/jquery.numpad.js
@@ -1,35 +1,3 @@
-/*
-	This file was forked from https://github.com/kabachello/jQuery.NumPad
-		with the license shown below.
-   
-	This license only applies to this file and others from the same project, which
-	also are prefixed with this header.  This file may have been modified, but the
-	license still applies.
-
-	----------------------------------------------------------------------------------
-   
-	The MIT License (MIT)
-
-	Copyright (c) 2014-2015 almasaeed2010
-
-	Permission is hereby granted, free of charge, to any person obtaining a copy of
-	this software and associated documentation files (the "Software"), to deal in
-	the Software without restriction, including without limitation the rights to
-	use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-	the Software, and to permit persons to whom the Software is furnished to do so,
-	subject to the following conditions:
-
-	The above copyright notice and this permission notice shall be included in all
-	copies or substantial portions of the Software.
-
-	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-	FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-	COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-	IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-	CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-*/
-
 /**
  * jQuery.NumPad
  *


### PR DESCRIPTION
Fixed bug where programmatically closing the numpad called the open function instead.
Fixed bug (maybe) where conflicts with the locale based number formatting on input fields with type="number" causes error.
Fixed bug where limit of x characters counted the decimal separator (example: limit of 4 digits only allowed 3333 or 33.3).
Fixed bug where comma as decimal separator did not allow the value to turn negative.

Note: Although almost every line was changed, most of the changes were variable renaming, function renaming, movement of blocks of code into separate functions, or the addition of braces and/or empty space.  With the exception of a few bug fixes, the logic is mostly the same.

Refactored code into a class which uses JQuery's `$.extend()` method to extend itself with the JQuery object of the newly created numpad element.  All functions in this class are arrow functions, so the meaning of the keyword `this` will always be class-scoped, regardless of where the function is called.  Most functions were prefixed with `numpad_` to ensure no conflict with other functions on the JQuery object extended by the class.

The intent of this refactoring is to make the code easier to read for all and more accessible to those who are less accustomed to JavaScript's quirks (like `this` meaning something different depending on where the function is being called from).